### PR TITLE
カレンダーのプラクティス提出

### DIFF
--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require 'date'
 require 'optparse'
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -18,9 +18,9 @@ def show_calendar(year, month)
   print "   " * first_wday
 
   (first_day..last_day).each do |date|
-		print date.day.to_s.rjust(2) + " "
-		puts if date.saturday?
-	end
+    print date.day.to_s.rjust(2) + " "
+    puts if date.saturday?
+  end
 
 	puts	
 end
@@ -46,8 +46,8 @@ year = options[:year] || Date.today.year
 
 # -m オプションに指定する引数が1~12以外の数値が入力された時にエラーメッセージの表示とプログラムの実行を終了するようにする
 if month < 1 || month >= 13
-	puts "-m オプションの指定は1~12のみ有効です"
-	exit
+  puts "-m オプションの指定は1~12のみ有効です"
+  exit
 end
 
 show_calendar(year,month)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -9,29 +9,29 @@ month = Date.today.month
 # program_calenderメソッドを定義。引数 year monthを指定。 
 def program_calendar(year,month)
 
-    # 変数から最初の月と最後の月を取得する 
-    first_day = Date.new(year, month, 1)
-    last_day = Date.new(year, month, -1)
+  # 変数から最初の月と最後の月を取得する 
+  first_day = Date.new(year, month, 1)
+  last_day = Date.new(year, month, -1)
 
-    # wdayメソッドで最初の月の日の曜日を数値で取得。（日:0,月:1,火:2)
-    first_wday = first_day.wday
+  # wdayメソッドで最初の月の日の曜日を数値で取得。（日:0,月:1,火:2)
+  first_wday = first_day.wday
 
-    # カレンダーの上部を表示　centerメソッドで幅が20で中央寄せ。
-    puts "#{month}月 #{year}".center(20," ")
-    puts "日 月 火 水 木 金 土"
+  # カレンダーの上部を表示　centerメソッドで幅が20で中央寄せ。
+  puts "#{month}月 #{year}".center(20," ")
+  puts "日 月 火 水 木 金 土"
 
-    # 初日の曜日まで空白を出力 曜日の値によって3スペースとfirst_wdayの数値で位置を決定。
-    print "   " * first_wday
+  # 初日の曜日まで空白を出力 曜日の値によって3スペースとfirst_wdayの数値で位置を決定。
+  print "   " * first_wday
 
-    # 各日付を繰り返し出力 date.saturday? 土曜日で改行
-    # .rjustメソッド(2)で幅2で右寄せ。
-    (first_day..last_day).each do |date|
-    print date.day.to_s.rjust(2) + " "
-    puts if date.saturday?
-    end
+  # 各日付を繰り返し出力 date.saturday? 土曜日で改行
+  # .rjustメソッド(2)で幅2で右寄せ。
+  (first_day..last_day).each do |date|
+  print date.day.to_s.rjust(2) + " "
+  puts if date.saturday?
+	end
 
-    # さらに改行してターミナルの字と重ならないようにする
-    puts
+# さらに改行してターミナルの字と重ならないようにする
+	puts
 
 end
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -18,8 +18,8 @@ def show_calendar(year, month)
   print "   " * first_wday
 
   (first_day..last_day).each do |date|
-  print date.day.to_s.rjust(2) + " "
-  puts if date.saturday?
+		print date.day.to_s.rjust(2) + " "
+		puts if date.saturday?
 	end
 
 	puts	
@@ -31,11 +31,11 @@ options = {}
 opt = OptionParser.new
 
 opt.on("-m month",Integer) do |month|
-    options[:month] = month
+  options[:month] = month
 end    
 
 opt.on("-y year", Integer) do |year| 
-    options[:year] = year 
+  options[:year] = year 
 end     
  
 opt.parse!(ARGV)
@@ -46,8 +46,8 @@ year = options[:year] || Date.today.year
 
 # -m オプションに指定する引数が1~12以外の数値が入力された時にエラーメッセージの表示とプログラムの実行を終了するようにする
 if month < 1 || month >= 13
-    puts "-m オプションの指定は1~12のみ有効です"
-    exit
+	puts "-m オプションの指定は1~12のみ有効です"
+	exit
 end
 
 show_calendar(year,month)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,0 +1,65 @@
+require 'date'
+require 'optparse'
+
+# Dateクラスのtodayメソッドと yearとmonthメソッドで今年と今月を取得し、変数year monthにそれぞれ格納する 
+year = Date.today.year
+month = Date.today.month
+
+# program_calenderメソッドを定義。引数 year monthを指定。 
+def program_calendar(year,month)
+
+    # 変数から最初の月と最後の月を取得する 
+    first_day = Date.new(year, month, 1)
+    last_day = Date.new(year, month, -1)
+
+    # wdayメソッドで最初の月の日の曜日を数値で取得。（日:0,月:1,火:2)
+    first_wday = first_day.wday
+
+    # カレンダーの上部を表示　centerメソッドで幅が20で中央寄せ。
+    puts "#{month}月 #{year}".center(20," ")
+    puts "日 月 火 水 木 金 土"
+
+    # 初日の曜日まで空白を出力 曜日の値によって3スペースとfirst_wdayの数値で位置を決定。
+    print "   " * first_wday
+
+    # 各日付を繰り返し出力 date.saturday? 土曜日で改行
+    # .rjustメソッド(2)で幅2で右寄せ。
+    (first_day..last_day).each do |date|
+    print date.day.to_s.rjust(2) + " "
+    puts if date.saturday?
+    end
+
+    # さらに改行してターミナルの字と重ならないようにする
+    puts
+
+end
+
+# オプションの空ハッシュを作成
+# .onメソッドで第２引数Integerにすることで数値をoptに登録
+# ARGVにコマンドライン引数を格納
+options = {}
+opt = OptionParser.new
+
+opt.on("-m month",Integer) do |month|
+    options[:month] = month
+end    
+# opt.on("-m month", Integer) { |month| options[:month] = month } 
+opt.on("-y year", Integer) do |year| 
+    options[:year] = year 
+end     
+# opt.on("-y year", Integer) { |year| options[:year] = year } 
+
+opt.parse!(ARGV)
+
+# オプションを指定したときは指定した月を、指定しないときは今月を取得して表示する
+month = options[:month] || Date.today.month
+# オプションを指定したときは指定した年を、指定しないときは今年を取得して表示する
+year = options[:year] || Date.today.year
+
+# -m オプションに指定する引数が1~12以外の数値が入力された時にエラーメッセージの表示とプログラムの実行を終了するようにする
+if month < 1 || month >= 13
+    puts "-m オプションの指定は1~12のみ有効です"
+    exit
+end
+
+program_calendar(year,month)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -7,7 +7,7 @@ year = Date.today.year
 month = Date.today.month
 
 # program_calenderメソッドを定義。引数 year monthを指定。 
-def program_calendar(year, month)
+def show_calendar(year, month)
 
   # 変数から最初の月と最後の月を取得する 
   first_day = Date.new(year, month, 1)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,59 +2,46 @@
 require 'date'
 require 'optparse'
 
-# Dateクラスのtodayメソッドと yearとmonthメソッドで今年と今月を取得し、変数year monthにそれぞれ格納する 
 year = Date.today.year
 month = Date.today.month
 
-# program_calenderメソッドを定義。引数 year monthを指定。 
 def show_calendar(year, month)
 
-  # 変数から最初の月と最後の月を取得する 
   first_day = Date.new(year, month, 1)
   last_day = Date.new(year, month, -1)
 
-  # wdayメソッドで最初の月の日の曜日を数値で取得。（日:0,月:1,火:2)
   first_wday = first_day.wday
 
-  # カレンダーの上部を表示　centerメソッドで幅が20で中央寄せ。
   puts "#{month}月 #{year}".center(20," ")
   puts "日 月 火 水 木 金 土"
 
-  # 初日の曜日まで空白を出力 曜日の値によって3スペースとfirst_wdayの数値で位置を決定。
   print "   " * first_wday
 
-  # 各日付を繰り返し出力 date.saturday? 土曜日で改行
-  # .rjustメソッド(2)で幅2で右寄せ。
   (first_day..last_day).each do |date|
   print date.day.to_s.rjust(2) + " "
   puts if date.saturday?
 	end
 
-# さらに改行してターミナルの字と重ならないようにする
-	puts
-
+	puts	
 end
 
-# オプションの空ハッシュを作成
-# .onメソッドで第２引数Integerにすることで数値をoptに登録
-# ARGVにコマンドライン引数を格納
+# -mで月を、-yで年を指定して表示できるようにする
+# 通常のcalコマンドは、-yのみ指定すると一年分のカレンダーを表示されますが、今回は指定した年の今月が表示。
 options = {}
 opt = OptionParser.new
 
 opt.on("-m month",Integer) do |month|
     options[:month] = month
 end    
-# opt.on("-m month", Integer) { |month| options[:month] = month } 
+
 opt.on("-y year", Integer) do |year| 
     options[:year] = year 
 end     
-# opt.on("-y year", Integer) { |year| options[:year] = year } 
-
+ 
 opt.parse!(ARGV)
 
-# オプションを指定したときは指定した月を、指定しないときは今月を取得して表示する
 month = options[:month] || Date.today.month
-# オプションを指定したときは指定した年を、指定しないときは今年を取得して表示する
+
 year = options[:year] || Date.today.year
 
 # -m オプションに指定する引数が1~12以外の数値が入力された時にエラーメッセージの表示とプログラムの実行を終了するようにする
@@ -63,4 +50,4 @@ if month < 1 || month >= 13
     exit
 end
 
-program_calendar(year,month)
+show_calendar(year,month)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -6,23 +6,22 @@ year = Date.today.year
 month = Date.today.month
 
 def show_calendar(year, month)
-
   first_day = Date.new(year, month, 1)
   last_day = Date.new(year, month, -1)
 
   first_wday = first_day.wday
 
-  puts "#{month}月 #{year}".center(20," ")
-  puts "日 月 火 水 木 金 土"
+  puts "#{month}月 #{year}".center(20, ' ')
+  puts '日 月 火 水 木 金 土'
 
-  print "   " * first_wday
+  print '   ' * first_wday
 
   (first_day..last_day).each do |date|
-    print date.day.to_s.rjust(2) + " "
+    print date.day.to_s.rjust(2) + ' '
     puts if date.saturday?
   end
 
-	puts	
+  puts
 end
 
 # -mで月を、-yで年を指定して表示できるようにする
@@ -30,14 +29,14 @@ end
 options = {}
 opt = OptionParser.new
 
-opt.on("-m month",Integer) do |month|
+opt.on('-m month', Integer) do |month|
   options[:month] = month
-end    
+end
 
-opt.on("-y year", Integer) do |year| 
-  options[:year] = year 
-end     
- 
+opt.on('-y year', Integer) do |year|
+  options[:year] = year
+end
+
 opt.parse!(ARGV)
 
 month = options[:month] || Date.today.month
@@ -46,8 +45,8 @@ year = options[:year] || Date.today.year
 
 # -m オプションに指定する引数が1~12以外の数値が入力された時にエラーメッセージの表示とプログラムの実行を終了するようにする
 if month < 1 || month >= 13
-  puts "-m オプションの指定は1~12のみ有効です"
+  puts '-m オプションの指定は1~12のみ有効です'
   exit
 end
 
-show_calendar(year,month)
+show_calendar(year, month)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -7,7 +7,7 @@ year = Date.today.year
 month = Date.today.month
 
 # program_calenderメソッドを定義。引数 year monthを指定。 
-def program_calendar(year,month)
+def program_calendar(year, month)
 
   # 変数から最初の月と最後の月を取得する 
   first_day = Date.new(year, month, 1)


### PR DESCRIPTION
お疲れ様です！
カレンダーのプラクティスを提出させていただきます！

- 引数を指定しない場合は、今月・今年のカレンダーが表示
- mで月を、-yで年を指定できる
- mで1~12以外の数字が入ったときは、コメントを表示できるようにしました

よろしくお願いします🙏

エビデンス画像を合わせて添付します。
## オプションなしで実行
1. OSで実行した場合
<img width="980" height="348" alt="CleanShot 2025-09-26 at 06 48 28@2x" src="https://github.com/user-attachments/assets/5252042e-5f97-4206-9f96-26c7768fa43b" />

2.  自分のcalコマンドで実行した場合
<img width="970" height="326" alt="CleanShot 2025-09-27 at 07 03 22@2x" src="https://github.com/user-attachments/assets/ef55532a-f3b8-442a-8bc1-e91fe1bd09df" />

## -mで月を-yで年を指定して実行
1. OSで実行した場合
<img width="1024" height="334" alt="CleanShot 2025-09-27 at 06 26 49@2x" src="https://github.com/user-attachments/assets/35a10b09-a0d0-415b-b95c-ae4f3fb86e89" />

2. 自分のcalコマンドで実行した場合
<img width="966" height="330" alt="CleanShot 2025-09-27 at 07 03 59@2x" src="https://github.com/user-attachments/assets/952d9230-803f-473a-80cf-6e620853cf70" />

月指定で、1~12 以外の数字が入ったら、処理を終了し、メッセージを表示する
<img width="988" height="148" alt="CleanShot 2025-09-27 at 07 04 15@2x" src="https://github.com/user-attachments/assets/4f0c112d-ac2d-448c-916c-0bbd2f8d6b28" />
